### PR TITLE
Relative symlink fallback and error improvements

### DIFF
--- a/bin/php-composter
+++ b/bin/php-composter
@@ -22,10 +22,10 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Verify that the bootstrap.php file exists.
-if [[ ! -f $package_root/.git/php-composter/includes/bootstrap.php ]]; then
+if [[ ! -f "$package_root/.git/php-composter/includes/bootstrap.php" ]]; then
     printf "PHP Composter bootstrap file was not found. Please reinstall.\n"
     exit
 fi
 
 # Launch the engine.
-$php $package_root/.git/php-composter/includes/bootstrap.php $hook $package_root ${@:1}
+$php "$package_root/.git/php-composter/includes/bootstrap.php" $hook "$package_root" ${@:1}


### PR DESCRIPTION
Type of pull request: _enhancement_

The standard `relativeSymlink` function of `Composer\Util\Filesystem` just tries to create a symlink. In most cases this will be no issue, but on Windows, it can be very annoying, especially because this project really depends on symbolic links.

This pull requests addresses this issue by the following steps:

- First, just try the composer filesystem to create the symlink
- If this doesn't work, try to create an absolute symlink
- When creating an absolute symlink triggers an error:
  - Check if the current platform is Windows and the symlink error is about privileges. If so, throw exception with the note that by running the command as administrator will fix this error
  - Check if there is already a file at the link location. If so, write an warning to the console
  - In all other cases, throw an exception with an error message containing the symlink target and link.
