### PR TITLE
bugfix - getStagedFiles get all modified files instead of staged only

### DIFF
--- a/src/BaseAction.php
+++ b/src/BaseAction.php
@@ -318,7 +318,7 @@ class BaseAction
             : " | grep {$pattern}";
 
         // Get the list of file names that are staged.
-        $diffCommand = $this->gitCall('diff-index --name-only --diff-filter=ACMR', $this->getAgainst(), $filter);
+        $diffCommand = $this->gitCall('diff --staged --name-only --diff-filter=ACMR', $this->getAgainst(), $filter);
 
         exec($diffCommand, $files, $return);
 


### PR DESCRIPTION
Original implementation is taking all modified files, despite of the method name suppose to take only "staged" files. 

Modify files A and B

git add A
git commit -m "test"

Expected:
Only file A will be selected by getStagedFiles
B will be in not staged state

Actual:
A and B will be selected by getStagedFiles
