### PR TITLE
Don't try to create symlink that already exists

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -209,6 +209,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 
         foreach (Hook::getSupportedHooks() as $githook) {
             $hookPath = $hooksPath . $githook;
+            if (is_link($hookPath)) {
+                continue;
+            }
             if (static::$io->isDebug()) {
                 static::$io->write(sprintf(
                     'Symlinking %1$s to %2$s',


### PR DESCRIPTION
Attempting to create a symlink that already exists fails and writes error messages, so check if it exists first.